### PR TITLE
Provide client-id in header.

### DIFF
--- a/twitch-helix-api.js
+++ b/twitch-helix-api.js
@@ -25,7 +25,8 @@ function apiRequest (path, query) {
     "path": '/helix/' + path + '?' + query,
     "method": 'GET',
     "headers": {
-      "Authorization": 'Bearer ' + config["twitch-client-token"]
+      "Authorization": 'Bearer ' + config["twitch-client-token"],
+      "Client-ID": config["twitch-client-id"]
     },
     "special": {
       "https": true


### PR DESCRIPTION
It says this is required in twitch's blog post but doesn't actually appear to be. Better safe than sorry.